### PR TITLE
Fix reach condition detection and add condition help modals

### DIFF
--- a/app.js
+++ b/app.js
@@ -563,6 +563,63 @@ class MahjongApp {
             this.selectedWinningTileSpan.textContent = '未選択';
         }
     }
+
+    showConditionModal(conditionType) {
+        const modal = document.getElementById('conditionModal');
+        const title = document.getElementById('modalTitle');
+        const description = document.getElementById('modalDescription');
+        const details = document.getElementById('modalDetails');
+        
+        const conditionInfo = {
+            'riichi': {
+                title: 'リーチ',
+                description: '聴牌時に宣言する1翻役です。',
+                details: '手牌を公開せずに、あと1枚で和了できる状態で宣言します。リーチ後は手牌を変更できません。'
+            },
+            'doubleRiichi': {
+                title: 'ダブルリーチ',
+                description: '配牌時に既に聴牌している場合の2翻役です。',
+                details: '第一ツモ前に聴牌していて、第一打でリーチをかけた場合に成立します。'
+            },
+            'ippatsu': {
+                title: '一発',
+                description: 'リーチ宣言後1巡以内に和了する1翻役です。',
+                details: 'リーチをかけた後、他家が鳴きを入れずに1巡以内に和了した場合に成立します。'
+            },
+            'haitei': {
+                title: '海底撈月',
+                description: '海底牌でツモ和了する1翻役です。',
+                details: '王牌を除いた最後の牌でツモ和了した場合に成立します。'
+            },
+            'houtei': {
+                title: '河底撈魚',
+                description: '海底牌の捨て牌でロン和了する1翻役です。',
+                details: '王牌を除いた最後の牌が捨てられた時にロン和了した場合に成立します。'
+            },
+            'rinshan': {
+                title: '嶺上開花',
+                description: '嶺上牌でツモ和了する1翻役です。',
+                details: 'カンをした後に引く嶺上牌でツモ和了した場合に成立します。'
+            },
+            'chankan': {
+                title: '槍槓',
+                description: '他家の加槓に対してロン和了する1翻役です。',
+                details: '他家が明刻に同じ牌を加えて槓子にする際、その牌でロン和了した場合に成立します。'
+            }
+        };
+        
+        const info = conditionInfo[conditionType];
+        if (info) {
+            title.textContent = info.title;
+            description.textContent = info.description;
+            details.textContent = info.details;
+            modal.style.display = 'block';
+        }
+    }
+    
+    closeConditionModal() {
+        document.getElementById('conditionModal').style.display = 'none';
+    }
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/index.html
+++ b/index.html
@@ -274,13 +274,34 @@
                 <div id="gameConditions" class="game-conditions" style="display: none;">
                     <h3>ゲーム条件</h3>
                     <div class="conditions-grid">
-                        <label><input type="checkbox" id="riichi"> リーチ</label>
-                        <label><input type="checkbox" id="doubleRiichi"> ダブルリーチ</label>
-                        <label><input type="checkbox" id="ippatsu"> 一発</label>
-                        <label><input type="checkbox" id="haitei"> 海底</label>
-                        <label><input type="checkbox" id="houtei"> 河底</label>
-                        <label><input type="checkbox" id="rinshan"> 嶺上</label>
-                        <label><input type="checkbox" id="chankan"> 槍槓</label>
+                        <label>
+                            <input type="checkbox" id="riichi"> リーチ
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('riichi')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="doubleRiichi"> ダブルリーチ
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('doubleRiichi')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="ippatsu"> 一発
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('ippatsu')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="haitei"> 海底
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('haitei')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="houtei"> 河底
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('houtei')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="rinshan"> 嶺上
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('rinshan')">?</button>
+                        </label>
+                        <label>
+                            <input type="checkbox" id="chankan"> 槍槓
+                            <button type="button" class="help-btn" onclick="app.showConditionModal('chankan')">?</button>
+                        </label>
                     </div>
                     
                     <div class="wind-selector">
@@ -367,6 +388,23 @@
     </div>
 
     <script src="https://docs.opencv.org/4.5.0/opencv.js"></script>
+    <!-- Condition Help Modal -->
+    <div id="conditionModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="modalTitle">条件の説明</h3>
+                <span class="close" onclick="app.closeConditionModal()">&times;</span>
+            </div>
+            <div class="modal-body">
+                <p id="modalDescription"></p>
+                <div id="modalDetails"></div>
+            </div>
+            <div class="modal-footer">
+                <button onclick="app.closeConditionModal()">閉じる</button>
+            </div>
+        </div>
+    </div>
+
     <script src="mahjong-recognition.js"></script>
     <script src="mahjong-scoring.js"></script>
     <script src="app.js"></script>

--- a/mahjong-scoring.js
+++ b/mahjong-scoring.js
@@ -13,6 +13,13 @@ class MahjongScoring {
 
         this.yakuList = {
             'riichi': { name: 'リーチ', han: 1 },
+            'doubleRiichi': { name: 'ダブルリーチ', han: 2 },
+            'ippatsu': { name: '一発', han: 1 },
+            'tsumo': { name: 'ツモ', han: 1 },
+            'haitei': { name: '海底撈月', han: 1 },
+            'houtei': { name: '河底撈魚', han: 1 },
+            'rinshan': { name: '嶺上開花', han: 1 },
+            'chankan': { name: '槍槓', han: 1 },
             'tanyao': { name: 'タンヤオ', han: 1 },
             'pinfu': { name: 'ピンフ', han: 1 },
             'iipeikou': { name: 'イーペーコー', han: 1 },
@@ -80,7 +87,7 @@ class MahjongScoring {
         }
 
         const bestGroup = groups[0];
-        const yaku = this.detectYaku(tiles, bestGroup);
+        const yaku = this.detectYaku(tiles, bestGroup, conditions);
         const han = yaku.reduce((sum, y) => sum + y.han, 0);
         const fu = this.calculateFu(bestGroup, conditions);
         const points = this.calculatePoints(han, fu);
@@ -232,7 +239,7 @@ class MahjongScoring {
         return [num + suit, (num + 1) + suit, (num + 2) + suit];
     }
 
-    detectYaku(tiles, groups) {
+    detectYaku(tiles, groups, conditions = {}) {
         const yaku = [];
         
         if (groups.type === 'kokushi') {
@@ -275,6 +282,38 @@ class MahjongScoring {
 
         const yakuhaiYaku = this.detectYakuhai(groups);
         yaku.push(...yakuhaiYaku);
+
+        if (conditions.riichi) {
+            yaku.push(this.yakuList.riichi);
+        }
+        
+        if (conditions.doubleRiichi) {
+            yaku.push(this.yakuList.doubleRiichi);
+        }
+        
+        if (conditions.ippatsu && conditions.riichi) {
+            yaku.push(this.yakuList.ippatsu);
+        }
+        
+        if (conditions.tsumo) {
+            yaku.push(this.yakuList.tsumo);
+        }
+        
+        if (conditions.haitei) {
+            yaku.push(this.yakuList.haitei);
+        }
+        
+        if (conditions.houtei) {
+            yaku.push(this.yakuList.houtei);
+        }
+        
+        if (conditions.rinshan) {
+            yaku.push(this.yakuList.rinshan);
+        }
+        
+        if (conditions.chankan) {
+            yaku.push(this.yakuList.chankan);
+        }
 
         if (yaku.length === 0) {
             yaku.push({ name: 'ノー役', han: 0 });

--- a/styles.css
+++ b/styles.css
@@ -526,6 +526,116 @@ select {
     flex-wrap: wrap;
 }
 
+/* Help button styles */
+.help-btn {
+    background: #007bff;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    margin-left: 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+}
+
+.help-btn:hover {
+    background: #0056b3;
+}
+
+/* Modal styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 10% auto;
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 500px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.modal-header {
+    background: #007bff;
+    color: white;
+    padding: 15px 20px;
+    border-radius: 8px 8px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.close {
+    color: white;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.close:hover {
+    opacity: 0.7;
+}
+
+.modal-body {
+    padding: 20px;
+    line-height: 1.6;
+}
+
+.modal-body p {
+    margin: 0 0 15px 0;
+    font-size: 1rem;
+}
+
+.modal-body ul {
+    margin: 10px 0;
+    padding-left: 20px;
+}
+
+.modal-body li {
+    margin: 5px 0;
+}
+
+.modal-footer {
+    padding: 15px 20px;
+    text-align: right;
+    border-top: 1px solid #dee2e6;
+}
+
+.modal-footer button {
+    background: #007bff;
+    color: white;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.modal-footer button:hover {
+    background: #0056b3;
+}
+
 @media (max-width: 768px) {
     .container {
         padding: 5px;
@@ -672,6 +782,34 @@ select {
     .meld-source-options label:has(input[type="radio"]:checked) {
         background: #e8f5e8;
         border-color: #4caf50;
+    }
+
+    /* Mobile modal adjustments */
+    .modal-content {
+        margin: 5% auto;
+        width: 95%;
+        max-width: none;
+    }
+
+    .modal-header h3 {
+        font-size: 1.1rem;
+    }
+
+    .modal-body {
+        padding: 15px;
+        font-size: 0.9rem;
+    }
+
+    .modal-footer {
+        padding: 10px 15px;
+    }
+
+    .help-btn {
+        width: 18px;
+        height: 18px;
+        font-size: 10px;
+        margin-left: 8px;
+        flex-shrink: 0;
     }
 }
 


### PR DESCRIPTION
- Update detectYaku method to accept conditions parameter
- Modify analyzeHand to pass conditions to detectYaku
- Add condition-based yaku detection logic for reach, double reach, ippatsu, etc.
- Add help buttons to condition checkboxes with modal explanations
- Implement modal functionality with Japanese explanations for beginners
- Add modal CSS styles with mobile responsiveness
- Fix core reach scoring bug that prevented winning with reach conditions